### PR TITLE
Updating deprecated endpoint from api.clickatell.com to platform.clickatell.com

### DIFF
--- a/clickatell/__init__.py
+++ b/clickatell/__init__.py
@@ -10,7 +10,7 @@ class Transport:
     the supported API methods
     """
 
-    endpoint = "api.clickatell.com"
+    endpoint = "platform.clickatell.com"
     status = {
         "001": "The message ID is incorrect or reporting is delayed.",
         "002": "The message could not be delivered and has been queued for attempted redelivery.",


### PR DESCRIPTION
<a href="">Clickatell</a> has made changes in their API. One of them is the base url(endpoint),  from 'api.clickatell.com' to 'platform.clickatell.com'.